### PR TITLE
feat(fallback cards): allow generating fallback cards forcefully

### DIFF
--- a/packages/webembeds-core/src/modules/WebembedHandler.ts
+++ b/packages/webembeds-core/src/modules/WebembedHandler.ts
@@ -16,7 +16,11 @@ export default class WebembedHandler {
 
   finalResponse: {} = {};
 
-  queryParams: {} = {};
+  queryParams: {
+    forceFallback: boolean,
+  } = {
+    forceFallback: false,
+  };
 
   platform: any = {};
 
@@ -147,6 +151,16 @@ export default class WebembedHandler {
    */
   // eslint-disable-next-line max-len
   generateOutput = async (): Promise<OEmbedResponseType | null> => new Promise((resolve, reject) => {
+    if (this.queryParams.forceFallback) {
+      tryEach([this.generateFallback],
+        (error: any, results: any): void => {
+          if (error) {
+            return reject(error);
+          }
+          return resolve(results);
+        });
+    }
+
     tryEach([this.generateOEmbed, this.generateManually, this.generateFallback],
       (error: any, results: any): void => {
         if (error) {

--- a/packages/webembeds-core/src/utils/html.utils.ts
+++ b/packages/webembeds-core/src/utils/html.utils.ts
@@ -154,20 +154,23 @@ function doRequest(url) {
 
 export const wrapFallbackHTML = async (data: urlMetadata.Result) => {
   let mainURL;
-  let coverImage: any = data["og:image"] || data["og:image"];
+
+  const desc = data["og:description"] || data.description;
+  let coverImage: any = data["og:image"] || data.image;
 
   if (isProd) {
-    coverImage = (await doRequest(data["og:image"])) || data["og:image"]; // Download the image and upload to our CDN
+    // Download the image and upload to our CDN
+    coverImage = (await doRequest(coverImage)) || coverImage;
   }
 
   try {
-    mainURL = new URL(data["og:url"]).hostname;
+    mainURL = new URL(data["og:url"] || data.url).hostname;
   } catch (error) {
     mainURL = "/";
   }
 
-  const description = `${data["og:description"].substring(0, 150)}${
-    data["og:description"].length > 150 ? "..." : ""
+  const description = `${desc.substring(0, 150)}${
+    desc.length > 150 ? "..." : ""
   }`;
 
   return `<html lang="en">
@@ -259,17 +262,17 @@ export const wrapFallbackHTML = async (data: urlMetadata.Result) => {
 		</style>
 			<meta charset="utf-8">
 			<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-			<title>${data["og:title"]}</title>
+			<title>${data["og:title"] || data.title}</title>
 		</head>
 		<body>
-			<a href="${data["og:url"]}" target="_blank" class="link-card">
+			<a href="${data["og:url"] || data.url}" target="_blank" class="link-card">
         <div class="link-image" style="background-image: url('${coverImage}?w=1600&h=840&fit=crop&crop=entropy&auto=format,enhance&q=60')">
           <!-- <img src="${coverImage}?w=1600&h=840&fit=crop&crop=entropy&auto=format,enhance&q=60" /> -->
         </div>
 				<div class="link-content">
-					<span class="big-text">${data["og:title"]}</span>
+					<span class="big-text">${data["og:title"] || data.title}</span>
 					<span class="small-desc">${description}</span>
-					<span class="small-desc host-name">${mainURL}</span>
+					<span class="small-desc host-name">${mainURL !== "/" ? mainURL : ""}</span>
 				</div>
 			</a>
 		</body>

--- a/packages/webembeds-core/src/utils/requestHandler.ts
+++ b/packages/webembeds-core/src/utils/requestHandler.ts
@@ -26,7 +26,8 @@ export const makeRequest = async (url: string): Promise<RequestResponseType> => 
 // eslint-disable-next-line max-len
 export const getMetaData = (url: string): Promise<Result> => new Promise((resolve, reject) => {
   urlMetaData(url).then(
-    (metadata: urlMetaData.Result) => { // success handler
+    (metadata: urlMetaData.Result) => {
+      // success handler
       // if (!metadata["og:image:width"] || !metadata["og:image:height"]) {
       // FastImage(metadata["og:image"], (error: any, imageData: any): any => {
       //   if (error) {


### PR DESCRIPTION
- Fix minor default values in fallback card generation functions.
- Allow support for a queryParam called `forceFallback` which should generate a fallback directly for the provided incoming URL.