### PR TITLE
Default embed card: Remove global css

### DIFF
--- a/example.md
+++ b/example.md
@@ -46,4 +46,4 @@
 
 %[https://fb.watch/4yOE3vHgMr]
 
-%[https://www.instagram.com/reel/CMgbGuOgo9l/?igshid=1pty8jxruxsd6]
+%[https://www.instagram.com/reel/CMgbGuOgo9l]

--- a/packages/webembeds-core/src/utils/html.utils.ts
+++ b/packages/webembeds-core/src/utils/html.utils.ts
@@ -176,16 +176,6 @@ export const wrapFallbackHTML = async (data: urlMetadata.Result) => {
   return `<html lang="en">
 		<head>
 		<style>
-    body,
-    html {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif
-    }
-
-    * {
-      margin: 0;
-      padding: 0
-    }
-
     .link-card {
       width: 100%;
       background: #eee;


### PR DESCRIPTION
Remove global styles in the default embed card as they can overwrite some of the styles where Webembeds is used.