### PR TITLE
add snappify as oembed provider

### DIFF
--- a/packages/webembeds-core/src/utils/providers/oembed.providers.js
+++ b/packages/webembeds-core/src/utils/providers/oembed.providers.js
@@ -2694,6 +2694,20 @@ const oEmbedProviders = [
     ],
   },
   {
+    provider_name: "snappify",
+    provider_url: "https://snappify.io/",
+    endpoints: [
+      {
+        schemes: [
+          "https://snappify.io/view/*",
+          "https://snappify.io/embed/*",
+        ],
+        url: "https://api.snappify.io/oembed/",
+        discovery: true,
+      },
+    ],
+  },
+  {
     provider_name: "SocialExplorer",
     provider_url: "https://www.socialexplorer.com/",
     endpoints: [


### PR DESCRIPTION
After discussing on Twitter (https://twitter.com/fazlerocks/status/1506668081153683459) I went ahead and added snappify as an oembed provider for webembeds :)

I've tested it on the demo page and it looked good. I am just not that sure regarding width and height, because it always just uses "100%" for both, even thought the snappify endpoint returns specific width and height.

It's not a real problem as snappify has scrolling if the snap is bigger than the iframe and also centers it if its smaller, but maybe someone with more experience on the webembeds project can check if that's fine

Here is a sample url for snappify whick can be used for embedding: https://snappify.io/view/bcc54061-6e8f-44c5-a4f4-1abcad520108