### PR TITLE
patch: allow snappify embeds to go into fullscreen mode

### DIFF
--- a/packages/webembeds-core/src/utils/providers/snappify.provider.ts
+++ b/packages/webembeds-core/src/utils/providers/snappify.provider.ts
@@ -30,7 +30,7 @@ export default class Snappify extends Platform {
       version: 0.1,
       type: "rich",
       title: "snappify",
-      html: `<div style="${wrapperDivStyle}"><div style="${aspectRatioDivStyle}"></div><iframe width="${data.width}" height="${data.height}" title="${data.title}" src="${host + path}?responsive" allow="clipboard-write" style="${iframeStyle}" frameborder="0"></iframe></div>`,
+      html: `<div style="${wrapperDivStyle}"><div style="${aspectRatioDivStyle}"></div><iframe width="${data.width}" height="${data.height}" title="${data.title}" src="${host + path}?responsive" allow="clipboard-write" allowfullscreen style="${iframeStyle}" frameborder="0"></iframe></div>`,
     };
   };
 }


### PR DESCRIPTION
as snappify now supports embedding Presentations, it's now also possible to watch the in full screen mode

with this change we allow the iframe to go into fullscreen mode when the user clicks the corresponding button