### PR TITLE
fix: use data.url instead of data['og:url'] in html utils

### DIFF
--- a/packages/webembeds-core/src/utils/html.utils.ts
+++ b/packages/webembeds-core/src/utils/html.utils.ts
@@ -150,7 +150,7 @@ export const wrapFallbackHTML = async (data: urlMetadata.Result) => {
   }
 
   try {
-    mainURL = new URL(data["og:url"] || data.url).hostname;
+    mainURL = new URL(data.url || data["og:url"]).hostname;
   } catch (error) {
     mainURL = "/";
   }
@@ -168,7 +168,7 @@ export const wrapFallbackHTML = async (data: urlMetadata.Result) => {
         <a
           target="_blank"
           rel="noopener"
-          href=${data["og:url"] || data.url}
+          href=${data.url || data["og:url"]}
           class="tw-we-w-full tw-we-group hover-tw-we-border-slate-900 tw-we-text-slate-900 tw-we-grid tw-we-border tw-we-border-slate-200 tw-we-grid-cols-12 tw-we-bg-slate-50 tw-we-shadow-md tw-we-rounded tw-we-overflow-hidden"
         >
           <div


### PR DESCRIPTION
This issue occur in my [blog](https://blog.msar.me/tutorials) where the urls are correct before the embed preview comes

after the embeds preview generated the links are broken maybe this issue is comes from the hashnode-core but instead of `og:url` here I use `data.url` so the embed preview can use the original url.

Issue happens in here: https://blog.msar.me/tutorials
Original link: https://blog.msar.me/series/laravel - works fine
Rendered link: https://hashnode.com/series/laravel-clo9xy1bz07vi7bnv92y77mmr - getting 404